### PR TITLE
Return sensor objects instead of events

### DIFF
--- a/src/query/sensor/models/sensor.model.ts
+++ b/src/query/sensor/models/sensor.model.ts
@@ -1,4 +1,26 @@
-import { model, Schema } from 'mongoose';
+import { model, Schema, Document, Types, Model } from 'mongoose';
+
+export interface ISensor extends Document {
+    _id: string;
+    nodeId: string;
+    ownerIds?: Types.Array<string>;
+    name?: string;
+    location: {
+        type: 'Point',
+        coordinates: Types.Array<number>,
+    };
+    baseObjectId: string;
+    dataStreams?: Types.Array<any>;
+    aim?: string;
+    description?: string;
+    manufacturer?: string;
+    active: boolean;
+    observationArea?: object;
+    documentationUrl?: string;
+    theme?: Types.Array<string>;
+    typeName: Types.Array<string>;
+    typeDetails?: Types.Array<object>;
+}
 
 export const SensorSchema = new Schema({
     _id: { type: String, required: true },
@@ -23,4 +45,4 @@ export const SensorSchema = new Schema({
 });
 
 SensorSchema.index({ location: '2dsphere' });
-export const Sensor = model('Sensor', SensorSchema);
+export const Sensor = model<ISensor, Model<ISensor>>('Sensor', SensorSchema);

--- a/src/query/sensor/sensor.module.ts
+++ b/src/query/sensor/sensor.module.ts
@@ -41,7 +41,7 @@ export class SensorQueryModule implements OnModuleInit {
     const database = process.env.MONGO_DATABASE || 'sensrnet';
 
     const url = 'mongodb://' + host + ':' + port.toString() + '/' + database;
-    connect(url, {useNewUrlParser: true, useUnifiedTopology: true, useCreateIndex: true});
+    connect(url, {useNewUrlParser: true, useUnifiedTopology: true, useCreateIndex: true, useFindAndModify: false});
 
     const onEvent = (_, eventMessage) => {
       const event = plainToClass(sensorEventType.getType(eventMessage.eventType), eventMessage.data);


### PR DESCRIPTION
Elke sensorEvent processor retouneert nu een sensor object. Hiermee kan de event naam en het gewijzigde document naar de connected clients verzonden worden. Een extra interface is toegevoegd voor de documents, deze kan tevens met de front-end gedeeld worden. Er zal nog gekeken moet worden naar hoe we robuust error handling willen doen. 

- `updateOne` vervangen met `findByIdAndUpdate` en, generieker, `findOneAndUpdate`. Hierdoor wordt het nieuwe object ook geretouneerd. Deze familie van functies zijn, net als updateOne, atomic.
- `useFindAndModify: false` is toegevoegd bij de mongoose.connect() als workaround voor de findAndModify() deprecation warning. Uitleg staat [hier](https://mongoosejs.com/docs/deprecations.html#findandmodify)