### PR TITLE
Move nodeId to sensor event.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   eventstore:
@@ -43,4 +43,5 @@ services:
 
 networks:
   backend:
+    name: backend
     driver: bridge

--- a/src/commands/sensor/aggregates/sensor.aggregate.ts
+++ b/src/commands/sensor/aggregates/sensor.aggregate.ts
@@ -25,11 +25,11 @@ export class SensorAggregate extends Aggregate {
     super();
   }
 
-  register(nodeId: string, ownerId: string, name: string, location: LocationBody,
+  register(ownerId: string, name: string, location: LocationBody,
            dataStreams: DataStreamBody[], aim: string, description: string, manufacturer: string,
            active: boolean, observationArea: object, documentationUrl: string, theme: string[],
            typeName: string, typeDetails: object) {
-    this.simpleApply(new SensorRegistered(this.aggregateId, nodeId, ownerId, name, location.longitude, location.latitude,
+    this.simpleApply(new SensorRegistered(this.aggregateId, ownerId, name, location.longitude, location.latitude,
         location.height, location.baseObjectId, aim, description, manufacturer, active, observationArea, documentationUrl,
         theme, typeName, typeDetails));
 

--- a/src/commands/sensor/commands/create.command.ts
+++ b/src/commands/sensor/commands/create.command.ts
@@ -5,7 +5,6 @@ import { DataStreamBody } from '../models/bodies/datastream-body';
 export class CreateSensorCommand implements ICommand {
   constructor(
     public readonly sensorId: string,
-    public readonly nodeId: string,
     public readonly ownerId: string,
     public readonly name: string,
     public readonly location: LocationBody,

--- a/src/commands/sensor/commands/create.handler.ts
+++ b/src/commands/sensor/commands/create.handler.ts
@@ -26,7 +26,7 @@ export class CreateSensorCommandHandler implements ICommandHandler<CreateSensorC
       const sensorAggregate = new SensorAggregate(command.sensorId);
       aggregate = this.publisher.mergeObjectContext(sensorAggregate);
 
-      aggregate.register(command.nodeId, command.ownerId,
+      aggregate.register(command.ownerId,
         command.name, command.location, command.dataStreams,
         command.aim, command.description, command.manufacturer,
         command.active, command.observationArea, command.documentationUrl,

--- a/src/commands/sensor/sensor.controller.ts
+++ b/src/commands/sensor/sensor.controller.ts
@@ -1,26 +1,26 @@
 import { v4 as uuidv4 } from 'uuid';
 import { CommandBus } from '@nestjs/cqrs';
-import { SensorIdParams, DataStreamIdParams } from './models/params/id-params';
-import { RegisterSensorBody } from './models/bodies/register-body';
-import { UpdateSensorBody } from './models/bodies/update-body';
+import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { LocationBody } from './models/bodies/location-body';
-import { ActivateSensorCommand } from './commands/activate.command';
+import { UpdateSensorBody } from './models/bodies/update-body';
 import { CreateSensorCommand } from './commands/create.command';
 import { UpdateSensorCommand } from './commands/update.command';
 import { DeleteSensorCommand } from './commands/delete.command';
 import { DataStreamBody } from './models/bodies/datastream-body';
+import { RegisterSensorBody } from './models/bodies/register-body';
+import { ActivateSensorCommand } from './commands/activate.command';
 import { DeactivateSensorCommand } from './commands/deactivate.command';
-import {ApiTags, ApiResponse, ApiOperation, ApiBearerAuth} from '@nestjs/swagger';
 import { DomainExceptionFilter } from './errors/domain-exception.filter';
 import { ShareOwnershipBody } from './models/bodies/shareownership-body';
-import { ShareSensorOwnershipCommand } from './commands/shareownership.command';
-import { UpdateSensorLocationCommand } from './commands/updatelocation.command';
 import { CreateDataStreamCommand } from './commands/createdatastream.command';
 import { DeleteDataStreamCommand } from './commands/deletedatastream.command';
 import { TransferOwnershipBody } from './models/bodies/transferownership-body';
+import { SensorIdParams, DataStreamIdParams } from './models/params/id-params';
+import { ShareSensorOwnershipCommand } from './commands/shareownership.command';
+import { UpdateSensorLocationCommand } from './commands/updatelocation.command';
+import { ApiTags, ApiResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { TransferSensorOwnershipCommand } from './commands/transferownership.command';
-import {Controller, Param, Post, Put, Body, Delete, UseFilters, Request, UseGuards} from '@nestjs/common';
-import {JwtAuthGuard} from '../../auth/jwt-auth.guard';
+import { Controller, Param, Post, Put, Body, Delete, UseFilters, Request, UseGuards } from '@nestjs/common';
 
 const NODE_ID = process.env.NODE_ID || '1';
 
@@ -42,7 +42,7 @@ export class OwnerController {
       dataStream.dataStreamId = uuidv4();
     }
 
-    await this.commandBus.execute(new CreateSensorCommand(sensorId, NODE_ID,
+    await this.commandBus.execute(new CreateSensorCommand(sensorId,
         req.user.ownerId, sensorBody.name, sensorBody.location,
         sensorBody.dataStreams, sensorBody.aim, sensorBody.description,
         sensorBody.manufacturer, sensorBody.active, sensorBody.observationArea,

--- a/src/events/sensor/sensor-registered.event.ts
+++ b/src/events/sensor/sensor-registered.event.ts
@@ -2,7 +2,6 @@ import {SensorEvent} from './sensor.event';
 
 export class SensorRegistered extends SensorEvent {
 
-  readonly nodeId: string;
   readonly ownerId: string;
   readonly name: string;
   readonly longitude: number;
@@ -19,14 +18,13 @@ export class SensorRegistered extends SensorEvent {
   readonly typeName: string;
   readonly typeDetails: object;
 
-  constructor(sensorId: string, nodeId: string, ownerId: string,
+  constructor(sensorId: string, ownerId: string,
               name: string, longitude: number, latitude: number, height: number,
               baseObjectId: string, aim: string, description: string,
               manufacturer: string, active: boolean, observationArea: object,
               documentationUrl: string, theme: string[], typeName: string,
               typeDetails: object) {
     super(sensorId);
-    this.nodeId = nodeId;
     this.ownerId = ownerId;
     this.name = name;
     this.longitude = longitude;

--- a/src/events/sensor/sensor.event.ts
+++ b/src/events/sensor/sensor.event.ts
@@ -1,8 +1,12 @@
-import {Event} from '../../event-store/event';
+import { v4 as uuidv4 } from 'uuid';
+import { Event } from '../../event-store/event';
+
+const NODE_ID = process.env.NODE_ID || uuidv4();
 
 export abstract class SensorEvent extends Event {
 
   readonly sensorId: string;
+  readonly nodeId: string = NODE_ID;
 
   constructor(sensorId: string) {
     super(sensorId);


### PR DESCRIPTION
Move nodeId to sensor event. It is static and should be available in all syncable events.