### PR TITLE
Process sync events

### DIFF
--- a/src/commands/sensor/commands/create.handler.ts
+++ b/src/commands/sensor/commands/create.handler.ts
@@ -10,8 +10,8 @@ import { SensorAlreadyExistsException } from '../errors/sensor-already-exists-ex
 export class CreateSensorCommandHandler implements ICommandHandler<CreateSensorCommand> {
   constructor(
     private readonly publisher: EventPublisher,
-    private readonly sensorRepository: SensorRepository,
     private readonly ownerRepository: OwnerRepository,
+    private readonly sensorRepository: SensorRepository,
   ) {}
 
   async execute(command: CreateSensorCommand): Promise<void> {

--- a/src/events/sensor/sensor.event.ts
+++ b/src/events/sensor/sensor.event.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Event } from '../../event-store/event';
 
-const NODE_ID = process.env.NODE_ID || uuidv4();
+export const NODE_ID = process.env.NODE_ID || uuidv4();
 
 export abstract class SensorEvent extends Event {
 

--- a/src/query/sensor/processors/sensor.processor.ts
+++ b/src/query/sensor/processors/sensor.processor.ts
@@ -17,7 +17,7 @@ export class SensorProcessor {
 
   private errorCallback(error: any): void {
     if (error) {
-      this.logError(event);
+      this.logError(error);
     }
   }
 
@@ -96,7 +96,12 @@ export class SensorProcessor {
       sensorData = {...sensorData, typeDetails: event.typeDetails};
     }
 
-    const sensor: ISensor = await new Sensor(sensorData).save();
+    let sensor: ISensor;
+    try {
+      sensor = await new Sensor(sensorData).save();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
@@ -132,11 +137,16 @@ export class SensorProcessor {
       sensorData = {...sensorData, typeDetails: event.typeDetails};
     }
 
-    const sensor: ISensor = await Sensor.findByIdAndUpdate(
-      event.sensorId,
-      sensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findByIdAndUpdate(
+        event.sensorId,
+        sensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
@@ -157,11 +167,16 @@ export class SensorProcessor {
       active: true,
     };
 
-    const sensor: ISensor = await Sensor.findByIdAndUpdate(
-      event.sensorId,
-      sensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findByIdAndUpdate(
+        event.sensorId,
+        sensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
@@ -171,29 +186,39 @@ export class SensorProcessor {
       active: false,
     };
 
-    const sensor: ISensor = await Sensor.findByIdAndUpdate(
-      event.sensorId,
-      sensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findByIdAndUpdate(
+        event.sensorId,
+        sensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
 
   async processOwnershipShared(event: SensorOwnershipShared): Promise<ISensor> {
     const updateSensorData = {
-      $push: {
+      $addToSet: {
         ownerIds: {
           $each: event.ownerIds,
         },
       },
     };
 
-    const sensor: ISensor = await Sensor.findByIdAndUpdate(
-      event.sensorId,
-      updateSensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findByIdAndUpdate(
+        event.sensorId,
+        updateSensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
@@ -210,11 +235,16 @@ export class SensorProcessor {
       },
     };
 
-    const sensor: ISensor = await Sensor.findOneAndUpdate(
-      filterData,
-      updateSensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findOneAndUpdate(
+        filterData,
+        updateSensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
@@ -254,17 +284,27 @@ export class SensorProcessor {
       dataStreamData = {...dataStreamData, dataQuality: event.dataQuality};
     }
 
+    const filterKwargs = {
+      '_id': event.sensorId,
+      'dataStreams.dataStreamId': { $ne: event.dataStreamId },
+    };
+
     const sensorData = {
       $push: {
         dataStreams: dataStreamData,
       },
     };
 
-    const sensor: ISensor = await Sensor.findByIdAndUpdate(
-      event.sensorId,
-      sensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findOneAndUpdate(
+        filterKwargs,
+        sensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
@@ -278,11 +318,16 @@ export class SensorProcessor {
       },
     };
 
-    const sensor: ISensor = await Sensor.findByIdAndUpdate(
-      event.sensorId,
-      sensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findByIdAndUpdate(
+        event.sensorId,
+        sensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }
@@ -300,11 +345,16 @@ export class SensorProcessor {
       sensorData = {...sensorData, baseObjectId: event.baseObjectId};
     }
 
-    const sensor: ISensor = await Sensor.findByIdAndUpdate(
-      event.sensorId,
-      sensorData,
-      this.errorCallback,
-    ).exec();
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findByIdAndUpdate(
+        event.sensorId,
+        sensorData,
+        {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
 
     return sensor;
   }

--- a/src/query/sensor/processors/sensor.processor.ts
+++ b/src/query/sensor/processors/sensor.processor.ts
@@ -21,6 +21,25 @@ export class SensorProcessor {
     }
   }
 
+  private logError(event) {
+    this.logger.error(`Error while updating projection for ${event.eventType}.`);
+  }
+
+  private async updateSensorById(sensorId, sensorData, event) {
+    let sensor: ISensor;
+    try {
+      sensor = await Sensor.findByIdAndUpdate(
+          sensorId,
+          sensorData,
+          {new: true},
+      ).exec();
+    } catch (_) {
+      this.errorCallback(event);
+    }
+
+    return sensor;
+  }
+
   protected logger: Logger = new Logger(this.constructor.name);
 
   async process(event): Promise<void> {
@@ -137,18 +156,7 @@ export class SensorProcessor {
       sensorData = {...sensorData, typeDetails: event.typeDetails};
     }
 
-    let sensor: ISensor;
-    try {
-      sensor = await Sensor.findByIdAndUpdate(
-        event.sensorId,
-        sensorData,
-        {new: true},
-      ).exec();
-    } catch (_) {
-      this.errorCallback(event);
-    }
-
-    return sensor;
+    return await this.updateSensorById(event.sensorId, sensorData, event);
   }
 
   async processDeleted(event: SensorDeleted): Promise<ISensor> {
@@ -167,18 +175,7 @@ export class SensorProcessor {
       active: true,
     };
 
-    let sensor: ISensor;
-    try {
-      sensor = await Sensor.findByIdAndUpdate(
-        event.sensorId,
-        sensorData,
-        {new: true},
-      ).exec();
-    } catch (_) {
-      this.errorCallback(event);
-    }
-
-    return sensor;
+    return await this.updateSensorById(event.sensorId, sensorData, event);
   }
 
   async processDeactivated(event: SensorDeactivated): Promise<ISensor> {
@@ -186,18 +183,7 @@ export class SensorProcessor {
       active: false,
     };
 
-    let sensor: ISensor;
-    try {
-      sensor = await Sensor.findByIdAndUpdate(
-        event.sensorId,
-        sensorData,
-        {new: true},
-      ).exec();
-    } catch (_) {
-      this.errorCallback(event);
-    }
-
-    return sensor;
+    return await this.updateSensorById(event.sensorId, sensorData, event);
   }
 
   async processOwnershipShared(event: SensorOwnershipShared): Promise<ISensor> {
@@ -209,18 +195,7 @@ export class SensorProcessor {
       },
     };
 
-    let sensor: ISensor;
-    try {
-      sensor = await Sensor.findByIdAndUpdate(
-        event.sensorId,
-        updateSensorData,
-        {new: true},
-      ).exec();
-    } catch (_) {
-      this.errorCallback(event);
-    }
-
-    return sensor;
+    return await this.updateSensorById(event.sensorId, updateSensorData, event);
   }
 
   async processOwnershipTransferred(event: SensorOwnershipTransferred): Promise<ISensor> {
@@ -318,18 +293,7 @@ export class SensorProcessor {
       },
     };
 
-    let sensor: ISensor;
-    try {
-      sensor = await Sensor.findByIdAndUpdate(
-        event.sensorId,
-        sensorData,
-        {new: true},
-      ).exec();
-    } catch (_) {
-      this.errorCallback(event);
-    }
-
-    return sensor;
+    return await this.updateSensorById(event.sensorId, sensorData, event);
   }
 
   async processLocationUpdated(event: SensorRelocated): Promise<ISensor> {
@@ -345,21 +309,6 @@ export class SensorProcessor {
       sensorData = {...sensorData, baseObjectId: event.baseObjectId};
     }
 
-    let sensor: ISensor;
-    try {
-      sensor = await Sensor.findByIdAndUpdate(
-        event.sensorId,
-        sensorData,
-        {new: true},
-      ).exec();
-    } catch (_) {
-      this.errorCallback(event);
-    }
-
-    return sensor;
-  }
-
-  private logError(event) {
-    this.logger.error(`Error while updating projection for ${event.eventType}.`);
+    return await this.updateSensorById(event.sensorId, sensorData, event);
   }
 }

--- a/src/query/sensor/processors/sensor.processor.ts
+++ b/src/query/sensor/processors/sensor.processor.ts
@@ -53,7 +53,6 @@ export class SensorProcessor {
   }
 
   async processCreated(event: SensorRegistered): Promise<ISensor> {
-
     let sensorData = {};
     sensorData = {
       _id: event.sensorId,


### PR DESCRIPTION
- Process events originating from other nodes delivered by the sync app.
- Fix bug where two datastreams are pushed when processing AdddDataStream in sensor processor. (changed use of await combined with error callback).
- Fix bug where the old document is send to clients over websockets instead of the new updated doc.