### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,21 @@ FROM node:12 AS builder
 LABEL maintainer="Wim Florijn <wim.florijn@kadaster.nl>"
 
 WORKDIR /app
+
 COPY ./package*.json ./
 RUN npm install
-COPY . .
-RUN npm test && \ 
-  npm run build
+
+COPY src src
+COPY tsconfig*.json ./
+
+RUN npm run test && \
+    npm run build && \
+    npm prune --production
 
 
 # Second Stage : Setup command to run your app using lightweight node image
-FROM node:12-alpine
+FROM node:12-slim
+
 WORKDIR /app
 
 ADD VERSION .
@@ -21,7 +27,8 @@ ADD VERSION .
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
 
-COPY --from=builder /app ./
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
 
 EXPOSE 3000
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$1" = "run" ]; then
-  exec npm run start:prod
+  exec node ./dist/main.js
 else
   exec "$@"
 fi


### PR DESCRIPTION
- The alpine image we changed to misses some critical dependencies. The base
image has been changed to node:slim for now, as more investigating has to be
done on how to get the alpine image to work. As a consequence, the built image
is larger (199MB instead of 147MB).
- Only the relevant files are copied to the production image.