### PR TITLE
JWT authentication for websockets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - MONGO_DATABASE=sensrnet
       - EVENT_STORE_PORT=1113
       - EVENT_STORE_HOST=eventstore
+      - REQUIRE_AUTHENTICATION=true
       - JWT_ACCESS_EXPIRES_IN=86400
       - JWT_SECRET=example-secret-key
       - JWT_REFRESH_EXPIRES_IN=604800

--- a/package-lock.json
+++ b/package-lock.json
@@ -8265,6 +8265,14 @@
         "pause": "0.0.1"
       }
     },
+    "passport-anonymous": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/passport-anonymous/-/passport-anonymous-1.0.1.tgz",
+      "integrity": "sha1-JB43J07ETft/bK0jS0HEODhrwRc=",
+      "requires": {
+        "passport-strategy": "1.x.x"
+      }
+    },
     "passport-jwt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "mongoose": "^5.9.15",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
+    "passport-anonymous": "^1.0.1",
     "passport-local": "^1.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/src/auth/access-anonymous-auth.guard.ts
+++ b/src/auth/access-anonymous-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class AccessAnonymousAuthGuard extends AuthGuard(['access', 'anonymous']) {}

--- a/src/auth/anonymous.strategy.ts
+++ b/src/auth/anonymous.strategy.ts
@@ -1,0 +1,14 @@
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-anonymous';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AnonymousStrategy extends PassportStrategy(Strategy, 'anonymous') {
+    constructor() {
+        super();
+    }
+
+    authenticate(): any {
+        return this.success({});
+    }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
 import { AccessJwtStrategy } from './access-jwt.strategy';
 import { RefreshJwtStrategy } from './refresh-jwt.strategy';
+import { AnonymousStrategy } from './anonymous.strategy';
 
 @Module({
     imports: [
@@ -25,6 +26,7 @@ import { RefreshJwtStrategy } from './refresh-jwt.strategy';
         LocalStrategy,
         AccessJwtStrategy,
         RefreshJwtStrategy,
+        AnonymousStrategy,
     ],
     exports: [
         AuthService,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -24,6 +24,10 @@ export class AuthService {
         }
     }
 
+    public async verifyToken(token: string): Promise<any> {
+        return this.jwtService.verifyAsync(token);
+    }
+
     async validateUser(username: string, pass: string): Promise<any> {
         const user = await this.usersService.findOne(username);
 

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,5 +1,5 @@
-import { v4 } from 'uuid';
 
 export const jwtConstants = {
-    secret: process.env.JWT_SECRET || v4(),
+    secret: process.env.JWT_SECRET || 'dev-secret',
+    enabled: process.env.REQUIRE_AUTHENTICATION ? process.env.REQUIRE_AUTHENTICATION !== 'false' : true,
 };

--- a/src/query/controller/sensor.controller.ts
+++ b/src/query/controller/sensor.controller.ts
@@ -1,15 +1,15 @@
 import { QueryBus } from '@nestjs/cqrs';
 import { SensorIdParams } from './model/id-params';
+import { jwtConstants } from '../../auth/constants';
 import { RetrieveSensorQuery } from '../model/sensor.query';
 import { RetrieveSensorsQuery } from '../model/sensors.query';
 import { AccessJwtAuthGuard } from '../../auth/access-jwt-auth.guard';
 import { RetrieveSensorsParams } from './model/retrieve-sensors-params';
+import { AccessAnonymousAuthGuard } from '../../auth/access-anonymous-auth.guard';
 import { DomainExceptionFilter } from '../../core/errors/domain-exception.filter';
 import { ApiTags, ApiResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { Controller, Get, Param, Query, UseGuards, UseFilters } from '@nestjs/common';
 
-@ApiBearerAuth()
-@UseGuards(AccessJwtAuthGuard)
 @ApiTags('Sensor')
 @Controller('Sensor')
 @UseFilters(new DomainExceptionFilter())
@@ -19,6 +19,8 @@ export class SensorController {
   ) {}
 
   @Get(':sensorId')
+  @ApiBearerAuth()
+  @UseGuards(AccessJwtAuthGuard)
   @ApiOperation({ summary: 'Retrieve Sensor' })
   @ApiResponse({ status: 200, description: 'Sensor retrieved' })
   @ApiResponse({ status: 400, description: 'Sensor retrieval failed' })
@@ -27,6 +29,8 @@ export class SensorController {
   }
 
   @Get()
+  @ApiBearerAuth()
+  @UseGuards(jwtConstants.enabled ? AccessJwtAuthGuard : AccessAnonymousAuthGuard)
   @ApiOperation({ summary: 'Retrieve Sensors' })
   @ApiResponse({ status: 200, description: 'Sensors retrieved' })
   @ApiResponse({ status: 400, description: 'Sensors retrieval failed' })

--- a/src/query/gateway/owner.gateway.ts
+++ b/src/query/gateway/owner.gateway.ts
@@ -13,7 +13,7 @@ export class OwnerGateway implements OnGatewayConnection {
 
     private logger: Logger = new Logger('OwnerGateway');
 
-    handleConnection(@ConnectedSocket() client: Socket, ...args: any[]): void {
+    handleConnection(@ConnectedSocket() client: Socket): void {
         this.logger.log(`Client connected: ${client.id}`);
     }
 
@@ -22,10 +22,7 @@ export class OwnerGateway implements OnGatewayConnection {
     }
 
     @SubscribeMessage('create')
-    handleEvent(
-        @MessageBody() data: string,
-        @ConnectedSocket() client: Socket,
-    ): string {
+    handleEvent(@MessageBody() data: string, @ConnectedSocket() client: Socket): string {
         // create the command
         return data;
     }

--- a/src/query/gateway/sensor.gateway.ts
+++ b/src/query/gateway/sensor.gateway.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
-import { QueryBus } from '@nestjs/cqrs';
 import { Socket, Server } from 'socket.io';
-import { RetrieveSensorsQuery } from '../model/sensors.query';
+import { jwtConstants } from '../../auth/constants';
+import { AuthService } from '../../auth/auth.service';
 import { WebSocketGateway, WebSocketServer, OnGatewayConnection, ConnectedSocket } from '@nestjs/websockets';
 
 @WebSocketGateway({
@@ -15,15 +15,26 @@ export class SensorGateway implements OnGatewayConnection {
     private logger: Logger = new Logger('SensorGateway');
 
     constructor(
-        private readonly queryBus: QueryBus,
+        private authService: AuthService,
     ) {}
 
-    async handleConnection(@ConnectedSocket() client: Socket, ...args: any[]): Promise<void> {
+    async handleConnection(@ConnectedSocket() client: Socket): Promise<void> {
         this.logger.log(`Client connected: ${client.id}`);
-        client.emit('Sensors', await this.queryBus.execute(new RetrieveSensorsQuery()));
+
+        if (jwtConstants.enabled) {
+            const authHeader: string = client.handshake.headers.authorization;
+            const authToken = authHeader && authHeader.length > 7 ? authHeader.substring(7, authHeader.length) : '';
+
+            try {
+                await this.authService.verifyToken(authToken);
+            } catch {
+                client.disconnect(true);
+                this.logger.log('Failed to authenticate websocket client.');
+            }
+        }
     }
 
-    emit(event: string, ...args: any[]) {
+    emit(event: string, ...args: any[]): void {
         this.server.emit(event, ...args);
     }
 }

--- a/src/query/query.module.spec.ts
+++ b/src/query/query.module.spec.ts
@@ -1,17 +1,18 @@
 import { Test } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
+import { AuthService } from '../auth/auth.service';
 import { OwnerGateway } from './gateway/owner.gateway';
-import { CommandBus, CqrsModule, EventPublisher } from '@nestjs/cqrs';
 import { SensorGateway } from './gateway/sensor.gateway';
 import { RetrieveSensorQuery } from './model/sensor.query';
 import { RetrieveSensorsQuery } from './model/sensors.query';
 import { OwnerProcessor } from './processor/owner.processor';
-import { EventStoreModule } from '../event-store/event-store.module';
 import { SensorProcessor } from './processor/sensor.processor';
 import { OwnerController } from './controller/owner.controller';
 import { SensorController } from './controller/sensor.controller';
 import { RetrieveOwnersQuery } from './model/retrieve-owner.query';
+import { EventStoreModule } from '../event-store/event-store.module';
 import { RetrieveSensorQueryHandler } from './handler/sensor.handler';
+import { CommandBus, CqrsModule, EventPublisher } from '@nestjs/cqrs';
 import { RetrieveSensorsQueryHandler } from './handler/sensors.handler';
 import { RetrieveOwnerQueryHandler } from './handler/retrieve-owner.handler';
 
@@ -27,6 +28,10 @@ const testObjects = [
 
 const mockRepository = {
     find: (values) => Object.keys(values).length ? testObjects.filter((owner) => owner._id === values._id) : testObjects,
+};
+
+const mockAuthService = {
+    verifyToken: async () => true,
 };
 
 describe('Query (integration)', () => {
@@ -52,6 +57,9 @@ describe('Query (integration)', () => {
                 RetrieveSensorQueryHandler,
                 RetrieveSensorsQueryHandler,
                 {
+                    provide: AuthService,
+                    useValue: mockAuthService,
+                }, {
                     provide: getModelToken('Owner'),
                     useValue: mockRepository,
                 }, {

--- a/src/query/query.module.ts
+++ b/src/query/query.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { UserSchema } from '../user/user.model';
+import { AuthModule } from '../auth/auth.module';
 import { MongooseModule } from '@nestjs/mongoose';
 import { SensorSchema } from './data/sensor.model';
 import { UserService } from '../user/user.service';
@@ -20,7 +21,6 @@ import { SensorESController } from './controller/sensor.es.controller';
 import { RetrieveSensorsQueryHandler } from './handler/sensors.handler';
 import { CheckpointModule } from './service/checkpoint/checkpoint.module';
 import { RetrieveOwnerQueryHandler } from './handler/retrieve-owner.handler';
-import { AuthModule } from '../auth/auth.module';
 
 @Module({
     imports: [

--- a/src/query/query.module.ts
+++ b/src/query/query.module.ts
@@ -20,10 +20,12 @@ import { SensorESController } from './controller/sensor.es.controller';
 import { RetrieveSensorsQueryHandler } from './handler/sensors.handler';
 import { CheckpointModule } from './service/checkpoint/checkpoint.module';
 import { RetrieveOwnerQueryHandler } from './handler/retrieve-owner.handler';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
     imports: [
         CqrsModule,
+        AuthModule,
         CheckpointModule,
         EventStoreModule,
         MongooseModule.forFeature([{name: 'User', schema: UserSchema}]),


### PR DESCRIPTION
- Authenticate with JWT token when connecting via websockets.
- Do not send all sensors immediatly when initializing a ws, retrieve these using GET/ Sensors
- JWT authentication for websockets and GET /Sensors can be controlled by env variable 'REQUIRE_AUTHENTICATION' for the kadaster viewer.