### PR TITLE
Updated datamodel central viewer

### DIFF
--- a/src/query/controller/handler/legal-entities.handler.ts
+++ b/src/query/controller/handler/legal-entities.handler.ts
@@ -3,21 +3,29 @@ import { InjectModel } from '@nestjs/mongoose';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { ILegalEntity } from '../../model/legal-entity.model';
 import { LegalEntitiesQuery } from '../query/legal-entities.query';
+import { IRelation } from '../../model/relation.model';
 
 @QueryHandler(LegalEntitiesQuery)
 export class LegalEntitiesQueryHandler implements IQueryHandler<LegalEntitiesQuery> {
     private limit = 50;
 
     constructor(
-        @InjectModel('LegalEntity') private model: Model<ILegalEntity>,
-    ) {}
+        @InjectModel('LegalEntity') private legalEntityModel: Model<ILegalEntity>,
+        @InjectModel('Relation') private relationModel: Model<IRelation>,
+    ) { }
 
     async execute(query: LegalEntitiesQuery): Promise<any> {
-        const fields: Record<string, any> = {originSync: false};
-        if (query.website) {
-            fields.website = {$regex: `^${query.website}`};
+        const fields: Record<string, any> = { originSync: false };
+
+        if (query.deviceId) {
+            const relationDocs: Array<IRelation> = await this.relationModel.find({ targetId: query.deviceId });
+            fields._id = { $in: relationDocs.map(doc => doc.legalEntityId) };
         }
 
-        return this.model.find(fields, {}, {limit: this.limit});
+        if (query.website) {
+            fields.website = { $regex: `^${query.website}` };
+        }
+
+        return this.legalEntityModel.find(fields, {}, { limit: this.limit });
     }
 }

--- a/src/query/controller/legal-entities.controller.ts
+++ b/src/query/controller/legal-entities.controller.ts
@@ -10,13 +10,13 @@ import { LegalEntitiesParams } from './model/legal-entities-params';
 @ApiTags('LegalEntities')
 @Controller('legalentities')
 export class LegalEntitiesController {
-  constructor(private readonly queryBus: QueryBus) {}
+  constructor(private readonly queryBus: QueryBus) { }
 
   @Get()
   @ApiOperation({ summary: 'Retrieve Legal Entities' })
   @ApiResponse({ status: 200, description: 'Legal Entities retrieved' })
   @ApiResponse({ status: 400, description: 'Legal Entities retrieval failed' })
-  async retrieveOrganizations(@Query() legalEntitiesParams: LegalEntitiesParams): Promise<any> {
-    return await this.queryBus.execute(new LegalEntitiesQuery(legalEntitiesParams.website));
+  async retrieveOrganizations(@Query() { website, deviceId }: LegalEntitiesParams): Promise<any> {
+    return await this.queryBus.execute(new LegalEntitiesQuery(website, deviceId));
   }
 }

--- a/src/query/controller/legal-entities.controller.ts
+++ b/src/query/controller/legal-entities.controller.ts
@@ -1,12 +1,13 @@
 import { QueryBus } from '@nestjs/cqrs';
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
-import { AccessJwtAuthGuard } from '../../auth/guard/access-jwt-auth.guard';
 import { LegalEntitiesQuery } from './query/legal-entities.query';
 import { ApiTags, ApiResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { LegalEntitiesParams } from './model/legal-entities-params';
+import { AccessAnonymousAuthGuard } from '../../auth/guard/access-anonymous-auth.guard';
+import { ILegalEntity } from '../model/legal-entity.model';
 
 @ApiBearerAuth()
-@UseGuards(AccessJwtAuthGuard)
+@UseGuards(AccessAnonymousAuthGuard)
 @ApiTags('LegalEntities')
 @Controller('legalentities')
 export class LegalEntitiesController {
@@ -16,7 +17,7 @@ export class LegalEntitiesController {
   @ApiOperation({ summary: 'Retrieve Legal Entities' })
   @ApiResponse({ status: 200, description: 'Legal Entities retrieved' })
   @ApiResponse({ status: 400, description: 'Legal Entities retrieval failed' })
-  async retrieveOrganizations(@Query() { website, deviceId }: LegalEntitiesParams): Promise<any> {
-    return await this.queryBus.execute(new LegalEntitiesQuery(website, deviceId));
+  async retrieveLegalEntities(@Query() { website, deviceId, allNodes }: LegalEntitiesParams): Promise<ILegalEntity[]> {
+    return await this.queryBus.execute(new LegalEntitiesQuery(website, deviceId, allNodes));
   }
 }

--- a/src/query/controller/legal-entities.controller.ts
+++ b/src/query/controller/legal-entities.controller.ts
@@ -18,6 +18,6 @@ export class LegalEntitiesController {
   @ApiResponse({ status: 200, description: 'Legal Entities retrieved' })
   @ApiResponse({ status: 400, description: 'Legal Entities retrieval failed' })
   async retrieveLegalEntities(@Query() { website, deviceId, allNodes }: LegalEntitiesParams): Promise<ILegalEntity[]> {
-    return await this.queryBus.execute(new LegalEntitiesQuery(website, deviceId, allNodes));
+    return this.queryBus.execute(new LegalEntitiesQuery(website, deviceId, allNodes));
   }
 }

--- a/src/query/controller/model/legal-entities-params.ts
+++ b/src/query/controller/model/legal-entities-params.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsOptional, IsEnum } from 'class-validator';
+import { IsString, IsOptional } from 'class-validator';
 
 export class LegalEntitiesParams {
   @IsString()

--- a/src/query/controller/model/legal-entities-params.ts
+++ b/src/query/controller/model/legal-entities-params.ts
@@ -7,6 +7,15 @@ export class LegalEntitiesParams {
   @ApiProperty({
     type: String,
     required: false,
+    description: 'Get the legal entities which are linked to a certain device.',
+  })
+  readonly deviceId: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    type: String,
+    required: false,
     description: 'Filter to apply to website.',
   })
   readonly website: string;

--- a/src/query/controller/model/legal-entities-params.ts
+++ b/src/query/controller/model/legal-entities-params.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsOptional } from 'class-validator';
+import { IsString, IsOptional, IsEnum } from 'class-validator';
 
 export class LegalEntitiesParams {
   @IsString()
@@ -19,4 +19,14 @@ export class LegalEntitiesParams {
     description: 'Filter to apply to website.',
   })
   readonly website: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    type: String,
+    default: 'false',
+    required: false,
+    description: 'Whether to include legalEntities from other nodes. The legal entities are filtered by creation in the current node by default',
+  })
+  readonly allNodes: string;
 }

--- a/src/query/controller/query/legal-entities.query.ts
+++ b/src/query/controller/query/legal-entities.query.ts
@@ -4,5 +4,6 @@ export class LegalEntitiesQuery implements IQuery {
     constructor(
         public readonly website?: string,
         public readonly deviceId?: string,
+        public readonly allNodes?: string,
     ) { }
 }

--- a/src/query/controller/query/legal-entities.query.ts
+++ b/src/query/controller/query/legal-entities.query.ts
@@ -3,5 +3,6 @@ import { IQuery } from '@nestjs/cqrs';
 export class LegalEntitiesQuery implements IQuery {
     constructor(
         public readonly website?: string,
-    ) {}
+        public readonly deviceId?: string,
+    ) { }
 }


### PR DESCRIPTION
Added `deviceId` and `allNodes` params to `GET /legalentities` for allowing to retrieve all legal entities for only certain device. This functionality is needed for the central viewer. For this reason, the endpoint now optionally needs authentication. The `allNodes` param has been added to also include entities which were created in other nodes.