### PR TITLE
Add contact email validator

### DIFF
--- a/src/command/controller/model/contact-details/contact-details.body.ts
+++ b/src/command/controller/model/contact-details/contact-details.body.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsOptional, MaxLength } from 'class-validator';
+import { IsString, IsOptional, MaxLength, Validate } from 'class-validator';
+import { OrganizationEmailValidator } from '../../validation/organization-email';
 
 export abstract class ContactDetailsBody {
     @IsString()
@@ -15,6 +16,7 @@ export abstract class ContactDetailsBody {
     @IsString()
     @IsOptional()
     @MaxLength(255)
+    @Validate(OrganizationEmailValidator)
     @ApiProperty({
         type: String,
         required: false,

--- a/src/command/controller/validation/organization-email.ts
+++ b/src/command/controller/validation/organization-email.ts
@@ -1,10 +1,12 @@
 import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
-import { Logger } from '@nestjs/common';
 
 @ValidatorConstraint({ name: 'organizationEmailValidator', async: false })
 export class OrganizationEmailValidator implements ValidatorConstraintInterface {
-    public supportedDomainNames = ['info', 'sensor', 'beheer', 'privacy', 'kcc', 'service', 'klant', 'gemeente'];
-    public validatorRegex = new RegExp(`^.*(${this.supportedDomainNames.join('|')}).*@.+[.].+$`);
+    public supportedNames = [
+        'info', 'sensor', 'beheer', 'privacy', 'kcc', 'service', 'klant', 'gemeente', 'support', 'help', 'ondersteuning',
+        'informatie', 'management', 'team', 'afdeling', 'data',
+    ];
+    public validatorRegex = new RegExp(`^.*(${this.supportedNames.join('|')}).*@.+[.].+$`);
 
     validate(email: string): boolean {
         return this.validatorRegex.test(email);
@@ -13,14 +15,14 @@ export class OrganizationEmailValidator implements ValidatorConstraintInterface 
     defaultMessage(args: ValidationArguments): string {
         let stringValue = '';
 
-        const supportedDomainNamesLength = this.supportedDomainNames.length;
+        const supportedDomainNamesLength = this.supportedNames.length;
         for (let i = 0; i < supportedDomainNamesLength; i++) {
             if (i === supportedDomainNamesLength - 1) {
-                stringValue += `'${this.supportedDomainNames[i]}'`;
+                stringValue += `'${this.supportedNames[i]}'`;
             } else if (i === supportedDomainNamesLength - 2) {
-                stringValue += `'${this.supportedDomainNames[i]}' or `;
+                stringValue += `'${this.supportedNames[i]}' or `;
             } else {
-                stringValue += `'${this.supportedDomainNames[i]}', `;
+                stringValue += `'${this.supportedNames[i]}', `;
             }
         }
 

--- a/src/command/controller/validation/organization-email.ts
+++ b/src/command/controller/validation/organization-email.ts
@@ -1,0 +1,29 @@
+import { ValidatorConstraint, ValidatorConstraintInterface, ValidationArguments } from 'class-validator';
+import { Logger } from '@nestjs/common';
+
+@ValidatorConstraint({ name: 'organizationEmailValidator', async: false })
+export class OrganizationEmailValidator implements ValidatorConstraintInterface {
+    public supportedDomainNames = ['info', 'sensor', 'beheer', 'privacy', 'kcc', 'service', 'klant', 'gemeente'];
+    public validatorRegex = new RegExp(`^.*(${this.supportedDomainNames.join('|')}).*@.+[.].+$`);
+
+    validate(email: string): boolean {
+        return this.validatorRegex.test(email);
+    }
+
+    defaultMessage(args: ValidationArguments): string {
+        let stringValue = '';
+
+        const supportedDomainNamesLength = this.supportedDomainNames.length;
+        for (let i = 0; i < supportedDomainNamesLength; i++) {
+            if (i === supportedDomainNamesLength - 1) {
+                stringValue += `'${this.supportedDomainNames[i]}'`;
+            } else if (i === supportedDomainNamesLength - 2) {
+                stringValue += `'${this.supportedDomainNames[i]}' or `;
+            } else {
+                stringValue += `'${this.supportedDomainNames[i]}', `;
+            }
+        }
+
+        return `${args.property} must be a valid e-mail and contain either ${stringValue}.`;
+    }
+}


### PR DESCRIPTION
closes #162

Validator toegevoegd die de ge-whiteliste emails checked. Een email moet de vorm hebben:
[any]* ('info', 'sensor', 'beheer' , etc) [any]* @ [any]+ . [any]+