### PR TITLE
Validation of commands

### DIFF
--- a/src/command/command.module.ts
+++ b/src/command/command.module.ts
@@ -1,12 +1,12 @@
+import { MongooseModule } from '@nestjs/mongoose';
+import { UserSchema } from '../user/model/user.model';
 import { Module, OnModuleInit } from '@nestjs/common';
 import { CqrsModule, EventBus, EventPublisher } from '@nestjs/cqrs';
-import { MongooseModule } from '@nestjs/mongoose';
 import { DeviceRepository } from '../core/repositories/device.repository';
 import { LegalEntityRepository } from '../core/repositories/legal-entity.repository';
 import { ObservationGoalRepository } from '../core/repositories/observation-goal.repository';
 import { EventStoreModule } from '../event-store/event-store.module';
 import { EventStorePublisher } from '../event-store/event-store.publisher';
-import { UserSchema } from '../user/model/user.model';
 import { DataStreamController } from './controller/data-stream.controller';
 import { DeviceController } from './controller/device.controller';
 import { LegalEntityController } from './controller/legal-entity.controller';
@@ -68,7 +68,7 @@ import { UpdateSensorCommandHandler } from './handler/model/sensor/update-sensor
         AddSensorCommandHandler,
         UpdateSensorCommandHandler,
         RemoveSensorCommandHandler,
-        // datastream
+        // data-stream
         AddDataStreamCommandHandler,
         RemoveDataStreamCommandHandler,
         UpdateDataStreamCommandHandler,

--- a/src/command/controller/data-stream.controller.ts
+++ b/src/command/controller/data-stream.controller.ts
@@ -16,8 +16,8 @@ import { AddDataStreamCommand } from '../command/data-stream/add-data-stream.com
 import { RemoveDataStreamCommand } from '../command/data-stream/remove-data-stream.command';
 import { UpdateDataStreamCommand } from '../command/data-stream/update-data-stream.command';
 import { LinkObservationGoalCommand } from '../command/data-stream/link-observationgoal.command';
-import { UnlinkObservationGoalCommand } from '../command/data-stream/unlink-observationgoal.command';
 import { Controller, Param, Post, Put, Body, Delete, UseFilters, UseGuards } from '@nestjs/common';
+import { UnlinkObservationGoalCommand } from '../command/data-stream/unlink-observationgoal.command';
 
 @ApiBearerAuth()
 @ApiTags('Datastream')

--- a/src/command/controller/legal-entity.controller.ts
+++ b/src/command/controller/legal-entity.controller.ts
@@ -9,16 +9,16 @@ import { DomainExceptionFilter } from '../../core/errors/domain-exception.filter
 import { ContactDetailsBody } from './model/contact-details/contact-details.body';
 import { ContactDetailsParams } from './model/legal-entity/contact-details.params';
 import { ApiTags, ApiResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
-import { UpdateLegalEntityBody as UpdateOrganizationBody } from './model/legal-entity/update-organization.body';
 import { RegisterOrganizationBody } from './model/legal-entity/register-organization.body';
 import { DeleteLegalEntityParams } from './model/legal-entity/delete-legal-entity.params';
 import { UpdateLegalEntityCommand } from '../command/legal-entity/update-legal-entity.command';
 import { RemoveLegalEntityCommand } from '../command/legal-entity/remove-legal-entity.command';
+import { UseFilters, Controller, Post, Body, Put, Delete, UseGuards, Param } from '@nestjs/common';
 import { RegisterOrganizationCommand } from '../command/legal-entity/register-organization.command';
 import { RemoveContactDetailsCommand } from '../command/legal-entity/remove-contact-details.command';
-import { UseFilters, Controller, Post, Body, Put, Delete, UseGuards, Param } from '@nestjs/common';
 import { UpdateContactDetailsCommand } from '../command/legal-entity/update-contact-details.command copy';
 import { AddPublicContactDetailsCommand } from '../command/legal-entity/add-public-contact-details.command';
+import { UpdateLegalEntityBody as UpdateOrganizationBody } from './model/legal-entity/update-organization.body';
 
 @ApiTags('LegalEntity')
 @Controller('legalentity')

--- a/src/command/controller/model/location/register-location.body.ts
+++ b/src/command/controller/model/location/register-location.body.ts
@@ -2,11 +2,12 @@ import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { LocationBody } from './location.body';
 import { LongitudeLatitudeValidator } from '../../validation/location';
-import { IsString, IsNumber, IsNotEmpty, IsArray, ArrayMinSize, ArrayMaxSize, Validate, IsOptional } from 'class-validator';
+import { IsString, IsNumber, IsNotEmpty, IsArray, ArrayMinSize, ArrayMaxSize, Validate, IsOptional, MaxLength } from 'class-validator';
 
 export class RegisterLocationBody extends LocationBody {
     @IsString()
     @IsOptional()
+    @MaxLength(255)
     @ApiProperty({
         type: String,
         required: false,

--- a/src/command/controller/observation-goal.controller.ts
+++ b/src/command/controller/observation-goal.controller.ts
@@ -9,8 +9,8 @@ import { DomainExceptionFilter } from '../../core/errors/domain-exception.filter
 import { ApiTags, ApiResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { ObservationGoalIdParams } from './model/observation-goal/observation-goal-id.params';
 import { UpdateObservationGoalBody } from './model/observation-goal/update-observation-goal.body';
-import { RegisterObservationGoalBody } from './model/observation-goal/register-observation-goal.body';
 import { Controller, Param, Post, Put, Body, Delete, UseFilters, UseGuards } from '@nestjs/common';
+import { RegisterObservationGoalBody } from './model/observation-goal/register-observation-goal.body';
 import { UpdateObservationGoalCommand } from '../command/observation-goal/update-observation-goal.command';
 import { RemoveObservationGoalCommand } from '../command/observation-goal/remove-observation-goal.command';
 import { RegisterObservationGoalCommand } from '../command/observation-goal/register-observation-goal.command';

--- a/src/command/handler/model/data-stream/add-datastream.handler.ts
+++ b/src/command/handler/model/data-stream/add-datastream.handler.ts
@@ -1,7 +1,7 @@
 import { validateLegalEntity } from '../../util/legal-entity.utils';
 import { UnknowObjectException } from '../../error/unknow-object-exception';
-import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
+import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { DeviceRepository } from '../../../../core/repositories/device.repository';
 import { AddDataStreamCommand } from '../../../command/data-stream/add-data-stream.command';
 import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';

--- a/src/command/handler/model/device/register-device.handler.ts
+++ b/src/command/handler/model/device/register-device.handler.ts
@@ -1,11 +1,11 @@
+import { validateLegalEntity } from '../../util/legal-entity.utils';
 import { AlreadyExistsException } from '../../error/already-exists-exception';
-import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { DeviceAggregate } from '../../../../core/aggregates/device.aggregate';
+import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
+import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { DeviceRepository } from '../../../../core/repositories/device.repository';
 import { RegisterDeviceCommand } from '../../../command/device/register-device.command';
-import { validateLegalEntity } from '../../util/legal-entity.utils';
 import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
-import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 
 @CommandHandler(RegisterDeviceCommand)
 export class RegisterDeviceCommandHandler implements ICommandHandler<RegisterDeviceCommand> {

--- a/src/command/handler/model/device/relocate-device.handler.ts
+++ b/src/command/handler/model/device/relocate-device.handler.ts
@@ -25,7 +25,7 @@ export class RelocateDeviceCommandHandler implements ICommandHandler<RelocateDev
     if (aggregate) {
       aggregate = this.publisher.mergeObjectContext(aggregate);
 
-      aggregate.relocateDevice(command.location);
+      aggregate.relocateDevice(command.legalEntityId, command.location);
       aggregate.commit();
     } else {
       throw new UnknowObjectException(command.deviceId);

--- a/src/command/handler/model/device/remove-device.handler.ts
+++ b/src/command/handler/model/device/remove-device.handler.ts
@@ -1,10 +1,10 @@
+import { validateLegalEntity } from '../../util/legal-entity.utils';
 import { UnknowObjectException } from '../../error/unknow-object-exception';
+import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { DeviceRepository } from '../../../../core/repositories/device.repository';
 import { RemoveDeviceCommand } from '../../../command/device/remove-device.command';
 import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
-import { validateLegalEntity } from '../../util/legal-entity.utils';
-import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 
 @CommandHandler(RemoveDeviceCommand)
 export class RemoveDeviceCommandHandler implements ICommandHandler<RemoveDeviceCommand> {

--- a/src/command/handler/model/device/update-device.handler.ts
+++ b/src/command/handler/model/device/update-device.handler.ts
@@ -1,10 +1,10 @@
 import { validateLegalEntity } from '../../util/legal-entity.utils';
 import { UnknowObjectException } from '../../error/unknow-object-exception';
+import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { DeviceRepository } from '../../../../core/repositories/device.repository';
 import { UpdateDeviceCommand } from '../../../command/device/update-device.command';
 import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
-import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 
 @CommandHandler(UpdateDeviceCommand)
 export class UpdateDeviceCommandHandler implements ICommandHandler<UpdateDeviceCommand> {

--- a/src/command/handler/model/legal-entity/add-contact-details.handler.ts
+++ b/src/command/handler/model/legal-entity/add-contact-details.handler.ts
@@ -1,7 +1,7 @@
+import { UnknowObjectException } from '../../error/unknow-object-exception';
 import { CommandHandler, EventPublisher, ICommandHandler } from '@nestjs/cqrs';
 import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
 import { AddPublicContactDetailsCommand } from '../../../command/legal-entity/add-public-contact-details.command';
-import { UnknowObjectException } from '../../error/unknow-object-exception';
 
 @CommandHandler(AddPublicContactDetailsCommand)
 export class AddPublicContactDetailsCommandHandler implements ICommandHandler<AddPublicContactDetailsCommand> {
@@ -21,5 +21,4 @@ export class AddPublicContactDetailsCommandHandler implements ICommandHandler<Ad
       throw new UnknowObjectException(command.legalEntityId);
     }
   }
-
 }

--- a/src/command/handler/model/observation-goal/add-observation-goal.handler.ts
+++ b/src/command/handler/model/observation-goal/add-observation-goal.handler.ts
@@ -1,12 +1,11 @@
 import { validateLegalEntity } from '../../util/legal-entity.utils';
-import { UnknowObjectException } from '../../error/unknow-object-exception';
+import { AlreadyExistsException } from '../../error/already-exists-exception';
 import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
+import { ObservationGoalAggregate } from '../../../../core/aggregates/observation-goal.aggregate';
 import { ObservationGoalRepository } from '../../../../core/repositories/observation-goal.repository';
 import { RegisterObservationGoalCommand } from '../../../command/observation-goal/register-observation-goal.command';
-import { AlreadyExistsException } from '../../error/already-exists-exception';
-import { ObservationGoalAggregate } from '../../../../core/aggregates/observation-goal.aggregate';
 
 @CommandHandler(RegisterObservationGoalCommand)
 export class RegisterObservationGoalCommandHandler implements ICommandHandler<RegisterObservationGoalCommand> {

--- a/src/command/handler/model/observation-goal/update-observation-goal.handler.ts
+++ b/src/command/handler/model/observation-goal/update-observation-goal.handler.ts
@@ -1,10 +1,10 @@
-import { UnknowObjectException } from '../../error/unknow-object-exception';
-import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
-import { UpdateObservationGoalCommand } from '../../../command/observation-goal/update-observation-goal.command';
-import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
-import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 import { validateLegalEntity } from '../../util/legal-entity.utils';
+import { UnknowObjectException } from '../../error/unknow-object-exception';
+import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
+import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
+import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
 import { ObservationGoalRepository } from '../../../../core/repositories/observation-goal.repository';
+import { UpdateObservationGoalCommand } from '../../../command/observation-goal/update-observation-goal.command';
 
 @CommandHandler(UpdateObservationGoalCommand)
 export class UpdateObservationGoalCommandHandler implements ICommandHandler<UpdateObservationGoalCommand> {

--- a/src/command/handler/model/sensor/add-sensor.handler.ts
+++ b/src/command/handler/model/sensor/add-sensor.handler.ts
@@ -1,9 +1,9 @@
+import { validateLegalEntity } from '../../util/legal-entity.utils';
 import { UnknowObjectException } from '../../error/unknow-object-exception';
 import { AddSensorCommand } from '../../../command/sensor/add-sensor.command';
 import { NoLegalEntityException } from '../../error/no-legal-entity-exception';
 import { ICommandHandler, EventPublisher, CommandHandler } from '@nestjs/cqrs';
 import { DeviceRepository } from '../../../../core/repositories/device.repository';
-import { validateLegalEntity } from '../../util/legal-entity.utils';
 import { LegalEntityRepository } from '../../../../core/repositories/legal-entity.repository';
 
 @CommandHandler(AddSensorCommand)

--- a/src/command/handler/util/legal-entity.utils.ts
+++ b/src/command/handler/util/legal-entity.utils.ts
@@ -1,7 +1,8 @@
 import { LegalEntityRepository } from '../../../core/repositories/legal-entity.repository';
 import { NonExistingLegalEntityException } from '../error/non-existing-legal-entity-exception';
 
-export async function validateLegalEntity(legalEntityRepository: LegalEntityRepository, legalEntityId: string): Promise<void> {
+export async function validateLegalEntity(legalEntityRepository: LegalEntityRepository,
+                                          legalEntityId: string): Promise<void> {
     if (!await legalEntityRepository.get(legalEntityId)) {
         throw new NonExistingLegalEntityException(legalEntityId);
     }

--- a/src/core/aggregates/device-state.ts
+++ b/src/core/aggregates/device-state.ts
@@ -1,15 +1,84 @@
+interface SensorState {
+  sensorId: string;
+}
+
+interface DataStreamState {
+  dataStreamId: string;
+  observationGoalIds: string[];
+}
+
 export interface DeviceState {
   id: string;
   legalEntityId: string;
 
   location?: number[];
+
+  sensors: SensorState[];
+
+  addSensor(sensorId: string): void;
+  removeSensor(sensorId: string): void;
+  hasSensor(sensorId: string): boolean;
+
+  dataStreams: DataStreamState[];
+
+  addDataStream(dataStreamId: string): void;
+  removeDataStream(dataStreamId: string): void;
+  hasDataStream(dataStreamId: string): boolean;
+
+  addObservationGoalId(dataStreamId: string, observationGoalId: string): void;
+  removeObservationGoalId(dataStreamId: string, observationGoalId: string): void;
+  hasObservationGoalId(dataStreamId: string, observationGoalId: string): boolean;
 }
 
 export class DeviceStateImpl implements DeviceState {
   public location;
+  public sensors = [];
+  public dataStreams = [];
 
   constructor(
       public readonly id: string,
       public readonly legalEntityId: string,
   ) {}
+
+  addSensor(sensorId: string): void {
+    this.sensors.push({ sensorId });
+  }
+
+  removeSensor(sensorId: string): void {
+    this.sensors = this.sensors.filter(x => x.sensorId !== sensorId);
+  }
+
+  hasSensor(sensorId: string): boolean {
+    return this.sensors.some(x => x.sensorId === sensorId);
+  }
+
+  addDataStream(dataStreamId: string): void {
+    this.dataStreams.push({ dataStreamId, observationGoalIds: [] });
+  }
+
+  removeDataStream(dataStreamId: string): void {
+    this.dataStreams = this.dataStreams.filter(x => x.dataStreamId !== dataStreamId);
+  }
+
+  hasDataStream(dataStreamId: string): boolean {
+    return this.dataStreams.some(x => x.dataStreamId === dataStreamId);
+  }
+
+  addObservationGoalId(dataStreamId: string, observationGoalId: string): void {
+    this.dataStreams
+        .filter(x => x.dataStreamId === dataStreamId)
+        .map(x => x.observationGoalIds.push(observationGoalId));
+  }
+
+  removeObservationGoalId(dataStreamId: string, observationGoalId: string): void {
+    this.dataStreams
+        .filter(x => x.dataStreamId === dataStreamId)
+        .map(x => x.observationGoalIds = x.observationGoalIds.filter(y => y !== observationGoalId));
+  }
+
+  hasObservationGoalId(dataStreamId: string, observationGoalId: string): boolean {
+    return this.dataStreams
+        .filter(x => x.dataStreamId === dataStreamId)
+        .some(x => x.observationGoalIds.includes(observationGoalId));
+  }
 }

--- a/src/core/aggregates/device-state.ts
+++ b/src/core/aggregates/device-state.ts
@@ -31,9 +31,9 @@ export interface DeviceState {
 }
 
 export class DeviceStateImpl implements DeviceState {
-  public location;
-  public sensors = [];
-  public dataStreams = [];
+  public location: number[];
+  public sensors: SensorState[] = [];
+  public dataStreams: DataStreamState[] = [];
 
   constructor(
       public readonly id: string,

--- a/src/core/aggregates/device-state.ts
+++ b/src/core/aggregates/device-state.ts
@@ -67,13 +67,13 @@ export class DeviceStateImpl implements DeviceState {
   addObservationGoalId(dataStreamId: string, observationGoalId: string): void {
     this.dataStreams
         .filter(x => x.dataStreamId === dataStreamId)
-        .map(x => x.observationGoalIds.push(observationGoalId));
+        .forEach(x => x.observationGoalIds.push(observationGoalId));
   }
 
   removeObservationGoalId(dataStreamId: string, observationGoalId: string): void {
     this.dataStreams
         .filter(x => x.dataStreamId === dataStreamId)
-        .map(x => x.observationGoalIds = x.observationGoalIds.filter(y => y !== observationGoalId));
+        .forEach(x => x.observationGoalIds = x.observationGoalIds.filter(y => y !== observationGoalId));
   }
 
   hasObservationGoalId(dataStreamId: string, observationGoalId: string): boolean {

--- a/src/core/aggregates/device.aggregate.ts
+++ b/src/core/aggregates/device.aggregate.ts
@@ -49,6 +49,12 @@ export class DeviceAggregate extends Aggregate {
   }
 
   validateObservationGoalId(dataStreamId: string, observationGoalId: string): void {
+    if (!this.state.hasObservationGoalId(dataStreamId, observationGoalId)) {
+      throw new UnknowObjectException(observationGoalId);
+    }
+  }
+
+  validateNoObservationGoalId(dataStreamId: string, observationGoalId: string): void {
     if (this.state.hasObservationGoalId(dataStreamId, observationGoalId)) {
       throw new AlreadyExistsException(observationGoalId);
     }
@@ -182,7 +188,9 @@ export class DeviceAggregate extends Aggregate {
 
   linkObservationGoal(sensorId: string, legalEntityId: string, dataStreamId: string, observationGoalId: string): void {
     this.validateLegalEntityId(legalEntityId);
-    this.validateObservationGoalId(dataStreamId, observationGoalId);
+    this.validateSensorId(sensorId);
+    this.validateDataStreamId(dataStreamId);
+    this.validateNoObservationGoalId(dataStreamId, observationGoalId);
 
     this.simpleApply(new ObservationGoalLinked(this.aggregateId, sensorId, legalEntityId, dataStreamId, observationGoalId));
   }
@@ -194,6 +202,9 @@ export class DeviceAggregate extends Aggregate {
 
   unlinkObservationGoal(sensorId: string, legalEntityId: string, dataStreamId: string, observationGoalId: string): void {
     this.validateLegalEntityId(legalEntityId);
+    this.validateSensorId(sensorId);
+    this.validateDataStreamId(dataStreamId);
+    this.validateObservationGoalId(dataStreamId, observationGoalId);
 
     this.simpleApply(new ObservationGoalUnlinked(this.aggregateId, sensorId, legalEntityId, dataStreamId, observationGoalId));
   }

--- a/src/core/aggregates/device.aggregate.ts
+++ b/src/core/aggregates/device.aggregate.ts
@@ -1,26 +1,27 @@
-import { Category } from '../../command/controller/model/category.body';
-import { RegisterLocationBody } from '../../command/controller/model/location/register-location.body';
-import { UpdateLocationBody } from '../../command/controller/model/location/update-location.body';
 import { Aggregate } from '../../event-store/aggregate';
+import { DeviceState, DeviceStateImpl } from './device-state';
 import { EventMessage } from '../../event-store/event-message';
-import { DatastreamAdded, getDatastreamAddedEvent } from '../events/sensordevice/datastream/added';
-import { getObservationGoalLinkedEvent, ObservationGoalLinked } from '../events/sensordevice/datastream/observation-goal-linked';
-import { ObservationGoalUnlinked } from '../events/sensordevice/datastream/observation-goal-unlinked/observation-goal-unlinked-v1.event';
-import { DatastreamRemoved, getDatastreamRemovedEvent } from '../events/sensordevice/datastream/removed';
-import { DatastreamUpdated, getDatastreamUpdatedEvent } from '../events/sensordevice/datastream/updated';
+import { Category } from '../../command/controller/model/category.body';
+import { getSensorAddedEvent, SensorAdded } from '../events/sensordevice/sensor/added';
 import { DeviceLocated, getDeviceLocatedEvent } from '../events/sensordevice/device/located';
-import { DeviceRegistered, getDeviceRegisteredEvent } from '../events/sensordevice/device/registered';
-import { DeviceRelocated, getDeviceRelocatedEvent } from '../events/sensordevice/device/relocated';
 import { DeviceRemoved, getDeviceRemovedEvent } from '../events/sensordevice/device/removed';
 import { DeviceUpdated, getDeviceUpdatedEvent } from '../events/sensordevice/device/updated';
-import { getSensorAddedEvent, SensorAdded } from '../events/sensordevice/sensor/added';
 import { getSensorRemovedEvent, SensorRemoved } from '../events/sensordevice/sensor/removed';
 import { getSensorUpdatedEvent, SensorUpdated } from '../events/sensordevice/sensor/updated';
-import { DeviceState, DeviceStateImpl } from './device-state';
 import { NotLegalEntityException } from '../../command/handler/error/not-legalentity-exception';
+import { UpdateLocationBody } from '../../command/controller/model/location/update-location.body';
+import { DatastreamAdded, getDatastreamAddedEvent } from '../events/sensordevice/datastream/added';
+import { DeviceRelocated, getDeviceRelocatedEvent } from '../events/sensordevice/device/relocated';
+import { RegisterLocationBody } from '../../command/controller/model/location/register-location.body';
+import { DeviceRegistered, getDeviceRegisteredEvent } from '../events/sensordevice/device/registered';
+import { DatastreamRemoved, getDatastreamRemovedEvent } from '../events/sensordevice/datastream/removed';
+import { DatastreamUpdated, getDatastreamUpdatedEvent } from '../events/sensordevice/datastream/updated';
+import { getObservationGoalLinkedEvent, ObservationGoalLinked } from '../events/sensordevice/datastream/observation-goal-linked';
+import { ObservationGoalUnlinked } from '../events/sensordevice/datastream/observation-goal-unlinked/observation-goal-unlinked-v1.event';
+import { UnknowObjectException } from '../../command/handler/error/unknow-object-exception';
+import { AlreadyExistsException } from '../../command/handler/error/already-exists-exception';
 
 export class DeviceAggregate extends Aggregate {
-
   state!: DeviceState;
 
   constructor(
@@ -29,10 +30,33 @@ export class DeviceAggregate extends Aggregate {
     super();
   }
 
+  validateLegalEntityId(legalEntityId: string): void {
+    if (this.state.legalEntityId !== legalEntityId) {
+      throw new NotLegalEntityException(this.aggregateId);
+    }
+  }
+
+  validateSensorId(sensorId: string): void {
+    if (!this.state.hasSensor(sensorId)) {
+      throw new UnknowObjectException(sensorId);
+    }
+  }
+
+  validateDataStreamId(dataStreamId: string): void {
+    if (!this.state.hasDataStream(dataStreamId)) {
+      throw new UnknowObjectException(dataStreamId);
+    }
+  }
+
+  validateObservationGoalId(dataStreamId: string, observationGoalId: string): void {
+    if (this.state.hasObservationGoalId(dataStreamId, observationGoalId)) {
+      throw new AlreadyExistsException(observationGoalId);
+    }
+  }
+
   registerDevice(legalEntityId: string, name: string, description: string, category: Category,
                  connectivity: string, location: RegisterLocationBody): void {
-    this.simpleApply(new DeviceRegistered(this.aggregateId, legalEntityId, name, description,
-      category, connectivity));
+    this.simpleApply(new DeviceRegistered(this.aggregateId, legalEntityId, name, description, category, connectivity));
     this.simpleApply(new DeviceLocated(this.aggregateId, location.name, location.description, location.location));
   }
 
@@ -48,17 +72,17 @@ export class DeviceAggregate extends Aggregate {
 
   updateDevice(legalEntityId: string, name: string, description: string, category: Category,
                connectivity: string, location: UpdateLocationBody): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new DeviceUpdated(this.aggregateId, legalEntityId, name, description, category, connectivity));
-      if (location) {
-        this.relocateDevice(location);
-      }
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
+    this.validateLegalEntityId(legalEntityId);
+
+    this.simpleApply(new DeviceUpdated(this.aggregateId, legalEntityId, name, description, category, connectivity));
+    if (location) {
+      this.relocateDevice(legalEntityId, location);
     }
   }
 
-  relocateDevice(location: UpdateLocationBody): void {
+  relocateDevice(legalEntityId: string, location: UpdateLocationBody): void {
+    this.validateLegalEntityId(legalEntityId);
+
     this.simpleApply(new DeviceRelocated(this.aggregateId, location.name, location.description, location.location));
   }
 
@@ -72,11 +96,9 @@ export class DeviceAggregate extends Aggregate {
   }
 
   removeDevice(legalEntityId: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new DeviceRemoved(this.aggregateId, legalEntityId));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+
+    this.simpleApply(new DeviceRemoved(this.aggregateId, legalEntityId));
   }
 
   onDeviceRemoved(eventMessage: EventMessage): void {
@@ -86,27 +108,24 @@ export class DeviceAggregate extends Aggregate {
 
   addSensor(sensorId: string, legalEntityId: string, name: string, description: string,
             type: string, manufacturer: string, supplier: string, documentation: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new SensorAdded(this.aggregateId, sensorId, legalEntityId, name, description,
-          type, manufacturer, supplier, documentation));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+
+    this.simpleApply(new SensorAdded(this.aggregateId, sensorId, legalEntityId, name, description,
+        type, manufacturer, supplier, documentation));
   }
 
   onSensorAdded(eventMessage: EventMessage): void {
     const event: SensorAdded = getSensorAddedEvent(eventMessage);
-    this.logger.debug(`Not implemented: aggregate.eventHandler(${event.constructor.name})`);
+    this.state.addSensor(event.sensorId);
   }
 
   updateSensor(sensorId: string, legalEntityId: string, name: string, description: string,
                type: string, manufacturer: string, supplier: string, documentation: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new SensorUpdated(this.aggregateId, sensorId, legalEntityId, name, description,
-          type, manufacturer, supplier, documentation));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+    this.validateSensorId(sensorId);
+
+    this.simpleApply(new SensorUpdated(this.aggregateId, sensorId, legalEntityId, name, description,
+        type, manufacturer, supplier, documentation));
   }
 
   onSensorUpdated(eventMessage: EventMessage): void {
@@ -115,47 +134,45 @@ export class DeviceAggregate extends Aggregate {
   }
 
   removeSensor(sensorId: string, legalEntityId: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new SensorRemoved(this.aggregateId, sensorId, legalEntityId));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+    this.validateSensorId(sensorId);
+
+    this.simpleApply(new SensorRemoved(this.aggregateId, sensorId, legalEntityId));
   }
 
   onSensorRemoved(eventMessage: EventMessage): void {
     const event: SensorRemoved = getSensorRemovedEvent(eventMessage);
-    this.logger.debug(`Not implemented: aggregate.eventHandler(${event.constructor.name})`);
+    this.state.removeSensor(event.sensorId);
   }
 
   addDataStream(sensorId: string, legalEntityId: string, dataStreamId: string, name: string,
                 description: string, unitOfMeasurement: Record<string, any>, observationArea: Record<string, any>,
                 theme: string[], dataQuality: string, isActive: boolean, isPublic: boolean, isOpenData: boolean,
                 containsPersonalInfoData: boolean, isReusable: boolean, documentation: string, dataLink: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new DatastreamAdded(this.aggregateId, sensorId, legalEntityId, dataStreamId, name,
-          description, unitOfMeasurement, observationArea, theme, dataQuality, isActive, isPublic, isOpenData,
-          containsPersonalInfoData, isReusable, documentation, dataLink));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+    this.validateSensorId(sensorId);
+
+    this.simpleApply(new DatastreamAdded(this.aggregateId, sensorId, legalEntityId, dataStreamId, name,
+        description, unitOfMeasurement, observationArea, theme, dataQuality, isActive, isPublic, isOpenData,
+        containsPersonalInfoData, isReusable, documentation, dataLink));
   }
 
   onDatastreamAdded(eventMessage: EventMessage): void {
     const event: DatastreamAdded = getDatastreamAddedEvent(eventMessage);
-    this.logger.debug(`Not implemented: aggregate.eventHandler(${event.constructor.name})`);
+    this.state.addDataStream(event.dataStreamId);
   }
 
   updateDataStream(sensorId: string, legalEntityId: string, dataStreamId: string, name: string,
                    description: string, unitOfMeasurement: Record<string, any>, observationArea: Record<string, any>,
                    theme: string[], dataQuality: string, isActive: boolean, isPublic: boolean, isOpenData: boolean,
                    containsPersonalInfoData: boolean, isReusable: boolean, documentation: string, dataLink: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new DatastreamUpdated(this.aggregateId, sensorId, legalEntityId, dataStreamId, name,
-          description, unitOfMeasurement, observationArea, theme, dataQuality, isActive, isPublic, isOpenData,
-          containsPersonalInfoData, isReusable, documentation, dataLink));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+    this.validateSensorId(sensorId);
+    this.validateDataStreamId(dataStreamId);
+
+    this.simpleApply(new DatastreamUpdated(this.aggregateId, sensorId, legalEntityId, dataStreamId, name,
+        description, unitOfMeasurement, observationArea, theme, dataQuality, isActive, isPublic, isOpenData,
+        containsPersonalInfoData, isReusable, documentation, dataLink));
   }
 
   onDatastreamUpdated(eventMessage: EventMessage): void {
@@ -164,41 +181,38 @@ export class DeviceAggregate extends Aggregate {
   }
 
   linkObservationGoal(sensorId: string, legalEntityId: string, dataStreamId: string, observationGoalId: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new ObservationGoalLinked(this.aggregateId, sensorId, legalEntityId, dataStreamId, observationGoalId));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+    this.validateObservationGoalId(dataStreamId, observationGoalId);
+
+    this.simpleApply(new ObservationGoalLinked(this.aggregateId, sensorId, legalEntityId, dataStreamId, observationGoalId));
   }
 
   onObservationGoalLinked(eventMessage: EventMessage): void {
     const event: ObservationGoalLinked = getObservationGoalLinkedEvent(eventMessage);
-    this.logger.debug(`Not implemented: aggregate.eventHandler(${event.constructor.name})`);
+    this.state.addObservationGoalId(event.dataStreamId, event.observationGoalId);
   }
 
   unlinkObservationGoal(sensorId: string, legalEntityId: string, dataStreamId: string, observationGoalId: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new ObservationGoalUnlinked(this.aggregateId, sensorId, legalEntityId, dataStreamId, observationGoalId));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+
+    this.simpleApply(new ObservationGoalUnlinked(this.aggregateId, sensorId, legalEntityId, dataStreamId, observationGoalId));
   }
 
   onObservationGoalUnlinked(eventMessage: EventMessage): void {
     const event: ObservationGoalLinked = getObservationGoalLinkedEvent(eventMessage);
-    this.logger.debug(`Not implemented: aggregate.eventHandler(${event.constructor.name})`);
+    this.state.removeObservationGoalId(event.dataStreamId, event.observationGoalId);
   }
 
   removeDataStream(sensorId: string, legalEntityId: string, dataStreamId: string): void {
-    if (this.state.legalEntityId === legalEntityId) {
-      this.simpleApply(new DatastreamRemoved(this.aggregateId, sensorId, legalEntityId, dataStreamId));
-    } else {
-      throw new NotLegalEntityException(this.aggregateId);
-    }
+    this.validateLegalEntityId(legalEntityId);
+    this.validateSensorId(sensorId);
+    this.validateDataStreamId(dataStreamId);
+
+    this.simpleApply(new DatastreamRemoved(this.aggregateId, sensorId, legalEntityId, dataStreamId));
   }
 
   onDatastreamRemoved(eventMessage: EventMessage): void {
     const event: DatastreamRemoved = getDatastreamRemovedEvent(eventMessage);
-    this.logger.debug(`Not implemented: aggregate.eventHandler(${event.constructor.name})`);
+    this.state.removeDataStream(event.dataStreamId);
   }
 }

--- a/src/core/aggregates/legal-entity.aggregate.ts
+++ b/src/core/aggregates/legal-entity.aggregate.ts
@@ -1,12 +1,12 @@
 import { Aggregate } from '../../event-store/aggregate';
 import { EventMessage } from '../../event-store/event-message';
-import { getPublicContactDetailsAddedEvent, PublicContactDetailsAdded } from '../events/legal-entity/contact-details/added';
+import { LegalEntityState, LegalEntityStateImpl } from './legal-entity-state';
+import { getLegalEntityRemovedEvent, LegalEntityRemoved } from '../events/legal-entity/removed';
+import { getOrganizationUpdatedEvent, OrganizationUpdated } from '../events/legal-entity/organization/updated';
 import { ContactDetailsRemoved, getContactDetailsRemovedEvent } from '../events/legal-entity/contact-details/removed';
 import { ContactDetailsUpdated, getContactDetailsUpdatedEvent } from '../events/legal-entity/contact-details/updated';
 import { getOrganizationRegisteredEvent, OrganizationRegistered } from '../events/legal-entity/organization/registered';
-import { getOrganizationUpdatedEvent, OrganizationUpdated } from '../events/legal-entity/organization/updated';
-import { getLegalEntityRemovedEvent, LegalEntityRemoved } from '../events/legal-entity/removed';
-import { LegalEntityState, LegalEntityStateImpl } from './legal-entity-state';
+import { getPublicContactDetailsAddedEvent, PublicContactDetailsAdded } from '../events/legal-entity/contact-details/added';
 
 export class LegalEntityAggregate extends Aggregate {
   state!: LegalEntityState;

--- a/src/core/events/abstract-event-type.ts
+++ b/src/core/events/abstract-event-type.ts
@@ -4,8 +4,6 @@ import { Event } from '../../event-store/event';
 
 export abstract class AbstractEventType {
 
-  constructor() { }
-
   public supportedTypes: Record<string, any> = {};
 
   getEvent(eventTypeName: ESEvent): Event {

--- a/src/core/events/sensordevice/device/located/device-located-v1.event.ts
+++ b/src/core/events/sensordevice/device/located/device-located-v1.event.ts
@@ -14,5 +14,4 @@ export class DeviceLocated extends SensorDeviceEvent {
         this.description = description;
         this.location = location;
     }
-
-}  
+}


### PR DESCRIPTION
De backend-validatie was in sommige gevallen niet toereikend, daarom is deze uitgebreid:

For devices, sensors, data-stream and observation-goals commands, the legal-entity id is validated.
For sensor commands, the sensor id is validated (for existence / duplicate).
For data-stream commands, the sensor-id, and data-stream ids are validated (for existence / duplicate).
For observation goal link / unlinks, the sensor-id, data-stream-id and observation-goal-id are validated (for existence / duplicate).

closes #108 