### PR TITLE
add some logging to failed requests

### DIFF
--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -26,7 +26,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   handleRequest(err, user, info) {
     // Can throw an exception based on either "info" or "err" arguments
     if (err || !user) {
-      Logger.error('Problem handling request');
+      Logger.error(`Problem handling request: ${JSON.stringify(info.message)}`);
       throw err || new UnauthorizedException();
     }
 


### PR DESCRIPTION
On failing Auth request, we now simply see "Problem handling request" in the logging. This is not very helpful. Expanded logging to include some message.

![image](https://user-images.githubusercontent.com/56066664/126625751-2fdf1885-9b99-4ccb-af64-e33918e43384.png)
