### PR TITLE
fix: fix linking observation goal

### DIFF
--- a/src/query/processor/device.es.listener.ts
+++ b/src/query/processor/device.es.listener.ts
@@ -316,8 +316,12 @@ export class DeviceEsListener extends AbstractQueryEsListener {
     async processObservationGoalLinked(event: ObservationGoalLinked): Promise<void> {
         const datastreamFilter = {
             _id: event.deviceId,
-            'datastreams._id': event.datastreamId,
-            'datastreams.observationGoalIds': { $ne: event.observationGoalId },
+            datastreams: {
+                $elemMatch: {
+                    _id: event.datastreamId,
+                    observationGoalIds: { $ne: event.observationGoalId },
+                },
+            },
         };
 
         const datastreamUpdate = {


### PR DESCRIPTION
The MongoDB filter had two conditions on nested documents. Due to notation, they were not necessarily the same embedded document. This led to problems when there are multiple datastreams, leading to each observation goal only being allowed once per device, instead of datastream.

The solution is to use Mongo's `$elemMatch`, which checks nested elements within arrays. For more information: https://docs.mongodb.com/manual/tutorial/query-array-of-documents/#a-single-nested-document-meets-multiple-query-conditions-on-nested-fields

Closes https://github.com/kadaster-labs/sensrnet-registry-backend/issues/138