### PR TITLE
Unit-of-measurement: body validation

### DIFF
--- a/src/command/api/model/data-stream/datastream.body.ts
+++ b/src/command/api/model/data-stream/datastream.body.ts
@@ -15,6 +15,7 @@ import {
 import Datastream from '../../../interfaces/datastream.interface';
 import { Theme } from '../theme.body';
 import { ObservedAreaBody } from './observed-area.body';
+import { UnitOfMeasurementBody } from './unit-of-measurement.body';
 
 export abstract class DatastreamBody implements Datastream {
     @IsUUID(4)
@@ -32,12 +33,14 @@ export abstract class DatastreamBody implements Datastream {
 
     @IsObject()
     @IsOptional()
+    @ValidateNested()
     @ApiProperty({
-        type: Object,
         required: false,
+        type: UnitOfMeasurementBody,
         description: 'Datastream unit of measurement.',
     })
-    readonly unitOfMeasurement: Record<string, any>;
+    @Type(() => UnitOfMeasurementBody)
+    readonly unitOfMeasurement: UnitOfMeasurementBody;
 
     @IsObject()
     @IsOptional()

--- a/src/command/api/model/data-stream/unit-of-measurement.body.ts
+++ b/src/command/api/model/data-stream/unit-of-measurement.body.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+
+export class UnitOfMeasurementBody {
+    @IsString()
+    @IsOptional()
+    @ApiProperty({
+        type: String,
+        required: false,
+        description: 'Unit of measurement name.',
+    })
+    readonly name: string;
+
+    @IsString()
+    @IsOptional()
+    @ApiProperty({
+        type: String,
+        required: false,
+        description: 'Unit of measurement symbol.',
+    })
+    readonly symbol: string;
+}


### PR DESCRIPTION
Validate the body of the unit-of-measurement. For now it must contain a name, and a symbol (see the sensorthingapi standard).