### PR TITLE
Return 404 when resource not found

### DIFF
--- a/src/command/repositories/user.service.ts
+++ b/src/command/repositories/user.service.ts
@@ -53,7 +53,7 @@ export class UserService {
 
     async revokeUserPermissionForOrganization(userId: string, legalEntityId: string): Promise<void> {
         this.logger.log(`revoke [user] permissions: [user: ${userId}] [organization: ${legalEntityId}]`);
-        const user = (await this.userPermissionsModel.findOne({ _id: userId })) as IUserPermissions;
+        const user: IUserPermissions = await this.userPermissionsModel.findById(userId);
 
         if (user.legalEntityId === legalEntityId) {
             const filter = { _id: userId };

--- a/src/commons/user/user.qry-service.ts
+++ b/src/commons/user/user.qry-service.ts
@@ -11,10 +11,10 @@ export class UserQueryService {
     ) {}
 
     async retrieveUser(userId: string): Promise<IUser | undefined> {
-        return this.userModel.findOne({ _id: userId });
+        return this.userModel.findById(userId);
     }
 
     async retrieveUserPermissions(userId: string): Promise<IUserPermissions> {
-        return this.userPermissionsModel.findOne({ _id: userId });
+        return this.userPermissionsModel.findById(userId);
     }
 }

--- a/src/query/api/device-controller.ts
+++ b/src/query/api/device-controller.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, Param, Query, UseFilters } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param, Query, UseFilters } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ValidatedUser } from '../../auth/validated-user';
 import { User } from '../../commons/decorators/user.decorator';
 import { DomainExceptionFilter } from '../../commons/errors/domain-exception.filter';
 import { RetrieveDeviceQuery } from '../model/device.query';
+import { IDevice } from '../model/device.schema';
 import { RetrieveDevicesQuery } from '../model/devices.query';
 import { DeviceIdParams } from './model/device-id-params';
 import { RetrieveDevicesParams } from './model/retrieve-devices-params';
@@ -20,8 +21,10 @@ export class DeviceController {
     @ApiOperation({ summary: 'Retrieve Device' })
     @ApiResponse({ status: 200, description: 'Device retrieved' })
     @ApiResponse({ status: 400, description: 'Device retrieval failed' })
-    async retrieveDevice(@Param() deviceIdParams: DeviceIdParams): Promise<any> {
-        return this.queryBus.execute(new RetrieveDeviceQuery(deviceIdParams.deviceId));
+    async retrieveDevice(@Param() deviceIdParams: DeviceIdParams): Promise<IDevice> {
+        const device: IDevice = await this.queryBus.execute(new RetrieveDeviceQuery(deviceIdParams.deviceId));
+        if (!device) throw new NotFoundException('User not found');
+        return device;
     }
 
     @Get()

--- a/src/query/api/device-controller.ts
+++ b/src/query/api/device-controller.ts
@@ -23,7 +23,7 @@ export class DeviceController {
     @ApiResponse({ status: 400, description: 'Device retrieval failed' })
     async retrieveDevice(@Param() deviceIdParams: DeviceIdParams): Promise<IDevice> {
         const device: IDevice = await this.queryBus.execute(new RetrieveDeviceQuery(deviceIdParams.deviceId));
-        if (!device) throw new NotFoundException('User not found');
+        if (!device) throw new NotFoundException('Device not found');
         return device;
     }
 

--- a/src/query/api/observation-goal.controller.ts
+++ b/src/query/api/observation-goal.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, NotFoundException, Param, Query } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 import { ApiTags, ApiResponse, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { Public } from '../../auth/public';
@@ -24,7 +24,11 @@ export class ObservationGoalController {
     async retrieveObservationGoal(
         @Param() observationGoalIdParams: ObservationGoalIdParams,
     ): Promise<IObservationGoal> {
-        return this.queryBus.execute(new ObservationGoalQuery(observationGoalIdParams.observationGoalId));
+        const observationGoal: IObservationGoal = await this.queryBus.execute(
+            new ObservationGoalQuery(observationGoalIdParams.observationGoalId),
+        );
+        if (!observationGoal) throw new NotFoundException('Observation Goal not found');
+        return observationGoal;
     }
 
     @Get()

--- a/src/query/handler/device.handler.ts
+++ b/src/query/handler/device.handler.ts
@@ -8,7 +8,7 @@ import { IDevice } from '../model/device.schema';
 export class RetrieveDeviceQueryHandler implements IQueryHandler<RetrieveDeviceQuery> {
     constructor(@InjectModel('Device') private model: Model<IDevice>) {}
 
-    async execute(query: RetrieveDeviceQuery): Promise<any> {
-        return this.model.findOne({ _id: query.id });
+    async execute(query: RetrieveDeviceQuery): Promise<IDevice> {
+        return this.model.findById(query.id);
     }
 }

--- a/src/query/handler/legal-entity.handler.ts
+++ b/src/query/handler/legal-entity.handler.ts
@@ -9,6 +9,6 @@ export class LegalEntityQueryHandler implements IQueryHandler<LegalEntityQuery> 
     constructor(@InjectModel('LegalEntity') private model: Model<ILegalEntity>) {}
 
     async execute(query: LegalEntityQuery): Promise<any> {
-        return this.model.findOne({ _id: query.id });
+        return this.model.findById(query.id);
     }
 }

--- a/src/query/processor/device.es.listener.ts
+++ b/src/query/processor/device.es.listener.ts
@@ -51,7 +51,7 @@ export class DeviceEsListener extends AbstractQueryEsListener {
             connectivity: event.connectivity,
         };
 
-        let device;
+        let device: IDevice;
         try {
             device = await new this.deviceModel(deviceData).save();
             await this.saveRelation(
@@ -64,7 +64,7 @@ export class DeviceEsListener extends AbstractQueryEsListener {
             this.errorCallback(event);
         }
 
-        return device as IDevice;
+        return device;
     }
 
     async processDeviceUpdated(event: DeviceUpdated): Promise<IDevice> {


### PR DESCRIPTION
Return 404 when resource not found. Relevant for Devices and ObservationGoals.

And some minor tidying of types and `findById()` instead of `findOne()` 🧹

Links to https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/197