### PR TITLE
fix: correctly remove deleted goal from multiple datastreams

### DIFF
--- a/src/query/processor/observation-goal.es.listener.ts
+++ b/src/query/processor/observation-goal.es.listener.ts
@@ -74,7 +74,7 @@ export class ObservationGoalEsListener extends AbstractQueryEsListener {
     async processObservationGoalRemoved(event: ObservationGoalRemoved): Promise<void> {
         try {
             const deviceFilter = { 'datastreams.observationGoalIds': event.observationGoalId };
-            const deviceUpdate = { $pull: { 'datastreams.$.observationGoalIds': event.observationGoalId } };
+            const deviceUpdate = { $pull: { 'datastreams.$[].observationGoalIds': event.observationGoalId } };
             await this.deviceModel.updateMany(deviceFilter, deviceUpdate);
 
             await this.deleteRelations(event.legalEntityId, TargetVariant.OBSERVATION_GOAL, event.observationGoalId);


### PR DESCRIPTION
Replaced `$` operator with `$[]`. Detailed explanation: https://docs.mongodb.com/manual/reference/operator/update/#operators

Fixes https://github.com/kadaster-labs/sensrnet-registry-backend/issues/152